### PR TITLE
Enable usage of Docker (ie, to build images inside Actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 -----------
 GitHub allows developpers to run GitHub Actions workflows on your own runners.
-This Docker image allows you to create your own runner on Docker.
+This Docker image allows you to create your own runners on Docker.
 
 This Docker Image is still under development: the linking process works but as it uses the Debian Buster image as a base, some actions may not work.
-My goal with this image is to be able to build Docker images (probably using Docker siblings or Docker in Docker).
 
 For now, there is only a Debian Buster image, but I may add more variants in the future.
 
@@ -19,12 +18,26 @@ Also, GitHub [recommends](https://help.github.com/en/github/automating-your-work
 
 ## Usage
 
+## Basic usage
 Use the following command to start listening for jobs:
 ```shell
 docker run -it --name my-runner \
     -e RUNNER_NAME=my-runner \
     -e RUNNER_TOKEN=token \
     -e RUNNER_REPOSITORY_URL=https://github.com/... \
+    tcardonne/github-runner
+```
+
+## Using Docker inside your Actions
+
+If you want to use Docker inside your runner (ie, build images in a workflow), you can enable Docker siblings by binding the host Docker daemon socket. Please keep in mind that doing this gives your actions full control on the Docker daemon.
+
+```shell
+docker run -it --name my-runner \
+    -e RUNNER_NAME=my-runner \
+    -e RUNNER_TOKEN=token \
+    -e RUNNER_REPOSITORY_URL=https://github.com/... \
+    -v /var/run/docker.sock:/var/run/docker.sock \
     tcardonne/github-runner
 ```
 
@@ -52,6 +65,8 @@ services:
         RUNNER_NAME: "my-runner"
         RUNNER_REPOSITORY_URL: ${RUNNER_REPOSITORY_URL}
         RUNNER_TOKEN: ${RUNNER_TOKEN}
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 You can create a `.env` to provide environment variables when using docker-compose :

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -20,11 +20,26 @@ LABEL maintainer="me@tcardonne.fr" \
     org.label-schema.docker.cmd="docker run -it tcardonne/github-runner:latest"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y curl git && \
-    rm -rf /var/lib/apt/lists/* && \
+    apt-get install -y \
+        curl \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        software-properties-common \
+        git \
+        sudo
+
+# Install Docker CLI
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+
+RUN rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN useradd -ms /bin/bash runner
+RUN useradd -ms /bin/bash runner && \
+    usermod -aG docker runner && \
+    usermod -aG sudo runner && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 WORKDIR /home/runner
 
 RUN curl -O https://githubassets.azureedge.net/runners/${GH_RUNNER_VERSION}/actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz \

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster
 
 ARG GH_RUNNER_VERSION="2.160.0"
+ARG DOCKER_COMPOSE_VERSION="1.24.1"
 
 ENV RUNNER_NAME=""
 ENV RUNNER_WORK_DIRECTORY="_work"
@@ -31,6 +32,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # Install Docker CLI
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+
+# Install Docker-Compose
+RUN curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get clean

--- a/debian-buster/entrypoint.sh
+++ b/debian-buster/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Ensure Docker socket
+if [[ -e "/var/run/docker.sock" ]]; then
+    sudo chgrp docker /var/run/docker.sock
+fi
+
 if [[ "$@" == "bash" ]]; then
     exec $@
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
         RUNNER_NAME: "my-runner"
         RUNNER_REPOSITORY_URL: ${RUNNER_REPOSITORY_URL}
         RUNNER_TOKEN: ${RUNNER_TOKEN}
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This PR enables the usage of Docker inside the Docker runner by using Docker siblings.

It allows developers to build images inside the runner, as well as running actions provided as a Docker image.