### PR TITLE
Use supervisord to start runner service

### DIFF
--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -28,7 +28,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         curl \
         software-properties-common \
         git \
-        sudo
+        sudo \
+        supervisor
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf
 
 # Install Docker CLI
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
@@ -56,6 +60,6 @@ RUN curl -O https://githubassets.azureedge.net/runners/${GH_RUNNER_VERSION}/acti
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["./run.sh"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 USER runner

--- a/debian-buster/supervisord.conf
+++ b/debian-buster/supervisord.conf
@@ -1,0 +1,12 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/fd/1
+logfile_maxbytes=0
+loglevel=error
+
+[program:runner]
+directory=/home/runner
+command=/home/runner/bin/runsvc.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.6"
+version: "3.7"
 
 services:
     runner:


### PR DESCRIPTION
Start a supervisord process to allow the runner to restart in case of update, as stated in #2 