### PR TITLE
Add ping to apt-get command

### DIFF
--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -32,7 +32,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         git \
         sudo \
         supervisor \
-        jq
+        jq \
+        iputils-ping
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
When an upgrade of the self-hosted runner runs, it tries to ping and spams the logs with errors. It works, this is just cleaning up the output (and potentially fixing a future bug if some necessary code is failing due to this)