### PR TITLE
Support organization-level runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ For now, there is only a Debian Buster image, but I may add more variants in the
 
 ## Important notes
 
-GitHub [recommends](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories) that you do **NOT** use self-hosted runners with public repositories, for security reasons.
+* GitHub [recommends](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories) that you do **NOT** use self-hosted runners with public repositories, for security reasons.
+* Organization level self-hosted runners are supported (see environment variables), but be advised that the GitHub API for organization level runners is still in public beta and subject to changes.
 
 ## Usage
 
@@ -49,6 +50,7 @@ services:
       environment:
         RUNNER_NAME: "my-runner"
         RUNNER_REPOSITORY_URL: ${RUNNER_REPOSITORY_URL}
+        #RUNNER_ORGANIZATION_URL: ${RUNNER_ORGANIZATION_URL}
         GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
@@ -57,6 +59,7 @@ services:
 You can create a `.env` to provide environment variables when using docker-compose :
 ```
 RUNNER_REPOSITORY_URL=https://github.com/your_url/your_repo
+# or RUNNER_ORGANIZATION_URL=https://github.com/your-organization
 GITHUB_ACCESS_TOKEN=the_runner_token
 ```
 
@@ -64,14 +67,24 @@ GITHUB_ACCESS_TOKEN=the_runner_token
 
 The following environment variables allows you to control the configuration parameters.
 
-| Name | Description | Default value |
+| Name | Description | Required/Default value |
 |------|---------------|-------------|
-| RUNNER_REPOSITORY_URL | The runner will be linked to this repository URL | Required |
-| GITHUB_ACCESS_TOKEN | Personal Access Token created on [your settings page](https://github.com/settings/tokens) with `repo` scole. Used to dynamically fetch a new runner token (recommended). | Required if `RUNNER_TOKEN` is not provided.
+| RUNNER_REPOSITORY_URL | The runner will be linked to this repository URL | Required if `RUNNER_ORGANIZATION_URL` is not provided |
+| RUNNER_ORGANIZATION_URL | The runner will be linked to this organization URL. *(Self-hosted runners API for organizations is currently in public beta and subject to changes)* | Required if `RUNNER_REPOSITORY_URL` is not provided |
+| GITHUB_ACCESS_TOKEN | Personal Access Token. Used to dynamically fetch a new runner token (recommended, see below). | Required if `RUNNER_TOKEN` is not provided.
 | RUNNER_TOKEN | Runner token provided by GitHub in the Actions page. These tokens are valid for a short period. | Required if `GITHUB_ACCESS_TOKEN` is not provided
 | RUNNER_WORK_DIRECTORY | Runner's work directory | `"_work"`
 | RUNNER_NAME | Name of the runner displayed in the GitHub UI | Hostname of the container
 | RUNNER_REPLACE_EXISTING | `"true"` will replace existing runner with the same name, `"false"` will use a random name if there is conflict | `"true"`
+
+## Runner Token
+
+In order to link your runner to your repository/organization, you need to provide a token. There is two way of passing the token :
+
+* via `GITHUB_ACCESS_TOKEN` (recommended), containing a [Personnal Access Token](https://github.com/settings/tokens). This token will be used to dynamically fetch a new runner token, as runner tokens are valid for a short period of time.
+  * For a single-repository runner, your PAT should have `repo` scopes.
+  * For an organization runner, your PAT should have `admin:org` scopes.
+* via `RUNNER_TOKEN`. This token is displayed in the Actions settings page of your organization/repository, when opening the "Add Runner" page.
 
 ## Runner auto-update behavior
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       environment:
         RUNNER_NAME: "my-runner"
         RUNNER_REPOSITORY_URL: ${RUNNER_REPOSITORY_URL}
+        #RUNNER_ORGANIZATION_URL: ${RUNNER_ORGANIZATION_URL}
         GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
* Add `RUNNER_ORGANIZATION_URL` environment variable,
* Update entrypoint to use the organizations API endpoint,
* Update README.md