### PR TITLE
fix: docker-compose version not being used

### DIFF
--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -48,7 +48,7 @@ RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 
 # Install Docker-Compose
-RUN curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
 RUN cd /tmp && \


### PR DESCRIPTION
### Description

`docker-compose` version was not in use. This should help utilize the version now.