### PR TITLE
Add support for private git repos (add openssh-client)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         zlib1g-dev \
         gettext \
         liblttng-ust0 \
-        libcurl4-openssl-dev && \
+        libcurl4-openssl-dev \
+        openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
Support for private repo requires the use of ssh-agent and ssh-add to add keys to allow fetching of private repository. This PR adds the openssl-client package to the image.