### PR TITLE
Adding nodejs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         liblttng-ust0 \
         libcurl4-openssl-dev \
         openssh-client && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - && \
+    apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
I discovered that I could not deploy terraform infrastructure using the dockerized version of the github runner... but that it would work fine using the native github runner. 

After poking at it the issue was that the github runner include nodejs that is required to actually run terraform... so I am proposing to add nodejs to the docker runner to make it work like the native github runner.