### PR TITLE
Support Personal Access Tokens with Github Enterprise

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,10 +56,16 @@ else
         _URL="$(echo "${RUNNER_URL/${_PROTO}/}")"
         _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
 
+        _GITHUB_API="https://api.github.com"
+        if ! [[ ${_URL} =~ "github.com" ]]; then
+            _HOSTNAME="$(echo "${_URL}" | grep / | cut -d / -f1)"
+            _GITHUB_API="https://${_HOSTNAME}/api/v3"
+        fi
+
         RUNNER_TOKEN="$(curl -XPOST -fsSL \
             -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/${SCOPE}/${_PATH}/actions/runners/registration-token" \
+            "${_GITHUB_API}/${SCOPE}/${_PATH}/actions/runners/registration-token" \
             | jq -r '.token')"
     fi
 


### PR DESCRIPTION
The `RUNNER_REPOSITORY_URL` and `RUNNER_ORGANIZATION_URL` combined with a `RUNNER_TOKEN` already support any Github Enterprise. Unfortunately, the recommended `GITHUB_ACCESS_TOKEN` does connect with `api.github.com` directly. Therefore one can not use this project together with a Github Enterprise instance.

With this PR, the Github API is automatically derived from the provided URL.